### PR TITLE
Update clipline to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ vecto = "0.1.1"
 umath = "0.0.7"
 fr = { version = "0.1.1", package = "fer", optional = true }
 slur = { version = "0.1.0", optional = true }
-clipline = "0.1.2"
+clipline = "0.4.0"
 minifb = { version = "0.25.0", default-features = false, features = [
     "x11",
     "wayland",


### PR DESCRIPTION
I can't benchmark this on my machine. See if it performs as well, feel free to discard. It's safer though, 0.1.2 has integer overflow. The fixme can be addressed by checking the size at construction or clamping the max coordinate to `i32::MAX` and using `Clip::from_max`, optionally replacing the `unwrap` with `unwrap_unchecked`.

Also note that 0.1.2 draws closed line segments, while 0.4 excludes the second point.